### PR TITLE
Add 'theme' to options for dark theme support

### DIFF
--- a/src/TwitterTimelineOptions.ts
+++ b/src/TwitterTimelineOptions.ts
@@ -15,6 +15,11 @@ export default interface TwitterTimelineOptions {
    */
   borderColor?: string;
   /**
+   * Sets the theme of the widget. Default = 'light'.
+   * 'light' or 'dark'
+   */
+  theme?: string;
+  /**
    * Toggle the display of design elements in the widget. This parameter is a space-separated list of values
    * Values: noheader, nofooter, noborders, transparent, noscrollbar
    */


### PR DESCRIPTION
Twitter has a theme option for their embeds, so passing in 'theme': 'dark' is what our project does to get it enabled. This PR should help formalize it a bit more.