### PR TITLE
Update Angular peer deps and Observable creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/ABD-dev/ngx-twitter-timeline/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^7.2.0",
-    "@angular/core": "^7.2.0"
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0"
   }
 }

--- a/src/lib/ngx-twitter-timeline.service.ts
+++ b/src/lib/ngx-twitter-timeline.service.ts
@@ -11,7 +11,7 @@ export class NgxTwitterTimelineService {
   constructor() { }
 
   loadScript(): Observable<any> {
-    return Observable.create(observer => {
+    return new Observable(observer => {
 
       this.startScriptLoad();
 


### PR DESCRIPTION
## Summary
- update Angular peer dependency versions in `package.json`
- use `new Observable()` instead of deprecated `Observable.create`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68432322444c83268a9862ec40fbff68